### PR TITLE
feat: 添加 R2/S3 渠道容量限制 UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sanyue_imghub",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sanyue_imghub",
-      "version": "2.3.3",
+      "version": "2.3.4",
       "dependencies": {
         "@element-plus/icons-vue": "^2.3.1",
         "@fortawesome/fontawesome-svg-core": "^6.6.0",


### PR DESCRIPTION
描述
功能说明
在上传设置页面为 R2 和 S3 渠道添加容量限制配置界面。

新增功能
容量限制开关
容量上限设置（GB）
阈值设置（%）
容量使用进度条显示
刷新按钮（重新统计容量）
实现细节
页面加载时使用 GET 请求读取容量统计（只读，不触发重建）
点击刷新按钮时使用 POST 请求重新统计（触发索引重建）
首次启用容量限制时提示用户是否立即统计
修改的文件
src/components/SysCogUpload.vue - 添加容量限制相关 UI 和逻辑
兼容性
✅ 默认不显示容量相关 UI（未启用时）
✅ 不影响现有用户的使用习惯
测试说明
由于时间原因，仅在新部署的环境中进行了简单验证（R2 渠道），未对各种 S3 数据库（AWS、Oracle、阿里云等）进行全面测试。建议作者在合并前进行更全面的测试。

配套后端
需要配合后端 PR 一起使用：https://github.com/lintonxue00/CloudFlare-ImgBed