### PR TITLE
feat: 在"上传设置->路径风格"旁边加入对路径风格功能的解释

### DIFF
--- a/src/components/SysCogUpload.vue
+++ b/src/components/SysCogUpload.vue
@@ -171,6 +171,12 @@
                     <el-input v-model="channel.endpoint" :disabled="channel.fixed"/>
                 </el-form-item>
                 <el-form-item label="路径风格" prop="pathStyle">
+                    <template #label>
+                        路径风格
+                        <el-tooltip content="S3 路径风格/虚拟主机风格，使用 OpenList 作为 S3 提供者时需打开此开关 <br> 路径风格：https://s3.example.com/下方存储桶名称/文件路径 <br> 虚拟主机风格：https://下方存储桶名称.s3.example.com/文件路径" placement="top" raw-content>
+                            <font-awesome-icon icon="question-circle" style="margin-left: 5px; cursor: pointer;"/>
+                        </el-tooltip>
+                    </template>
                     <el-switch v-model="channel.pathStyle" :disabled="channel.fixed"/>
                 </el-form-item>
                 <el-form-item label="存储桶名称" prop="bucketName">


### PR DESCRIPTION
没接触过 Vue，有错就帮指正一下吧 orz

```vue
<el-tooltip content="S3 路径风格/虚拟主机风格，使用 OpenList 作为 S3 提供者时需打开此开关 <br> 路径风格：https://s3.example.com/下方存储桶名称/文件路径 <br> 虚拟主机风格：https://下方存储桶名称.s3.example.com/文件路径" placement="top" raw-content>
```

<img width="958" height="377" alt="image" src="https://github.com/user-attachments/assets/e786b42a-7e6e-44de-a859-459a1eaa62cc" />
